### PR TITLE
Resolve issue where autoprefixer failed on old versions of npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ conf-schedule-single.min.js
 conf-schedule.min.js
 admin-post-speakers.min.js
 admin-post-schedule.min.js
+/node_modules/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,9 @@ var watch = require('gulp-watch');
 var autoprefixer = require('gulp-autoprefixer');
 var rename = require('gulp-rename');
 
+// Compatibility for older versions of npm
+require('es6-promise').polyfill();
+
 // Define the source paths for each file type
 var src = {
     scss: './assets/scss/*.scss',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.0",
-    "gulp-watch": "^4.3.8"
+    "gulp-watch": "^4.3.8",
+    "es6-promise": "~4.0.5"
   }
 }


### PR DESCRIPTION
Long story short I encountered the issue described in http://stackoverflow.com/questions/32490328/gulp-autoprefixer-throwing-referenceerror-promise-is-not-defined when running `gulp`; upgrading node was not an option. The described workaround fixed the issue.